### PR TITLE
cast void* to int* before modifying in Race Condition. Resolves #170

### DIFF
--- a/threads/threads.tex
+++ b/threads/threads.tex
@@ -209,7 +209,7 @@ The following is the canonical race condition.
 
 \begin{lstlisting}[language=C]
 void *thread_main(void *p) {
-  int *p_int= (int*) p;
+  int *p_int = (int*) p;
   int x = *p_int;
   x += x;
   *p_int = x;

--- a/threads/threads.tex
+++ b/threads/threads.tex
@@ -209,8 +209,10 @@ The following is the canonical race condition.
 
 \begin{lstlisting}[language=C]
 void *thread_main(void *p) {
-  int *x = (int*) p;
-  *x = *x + *x;
+  int *p_int= (int*) p;
+  int x = *p_int;
+  x += x;
+  *p_int = x;
   return NULL;
 }
 

--- a/threads/threads.tex
+++ b/threads/threads.tex
@@ -209,9 +209,8 @@ The following is the canonical race condition.
 
 \begin{lstlisting}[language=C]
 void *thread_main(void *p) {
-  int x = *p;
-  x += x;
-  *p = x;
+  int *x = (int*) p;
+  *x = *x + *x;
   return NULL;
 }
 


### PR DESCRIPTION
In order to access and modify the underlying int value of a void* we must first cast to int*. Then we use the int* to modify the value. Without this cast running `gcc file.c` throws an error. Resolves issue #170    