### PR TITLE
Fix code mistake under introc chapter

### DIFF
--- a/introc/pointers.tex
+++ b/introc/pointers.tex
@@ -55,7 +55,7 @@ It is the same for all primitive types but structs are a little different.
 Reading works roughly the same way, except you put the variable in the spot that it needs the value.
 
 \begin{lstlisting}[language=C]
-int double = *ptr * 2
+int doubled = *ptr * 2;
 \end{lstlisting}
 
 Reading and writing to non-primitive types gets tricky.


### PR DESCRIPTION
Clearly the original code snippet is problematic, since `double` is a keyword in C, this wouldn't compile. Besides, it doesn't have a semi-colon after it. I guess this is a quick fix.