### PR TITLE
Typo: Update language_facilities.tex

### DIFF
--- a/introc/language_facilities.tex
+++ b/introc/language_facilities.tex
@@ -247,7 +247,7 @@ if (connect(...)) {
 }
 \end{lstlisting}
 
-	    \item \keyword{inline} is a compiler keyword that tells the compiler it's okay to moit the C function call procedure and "paste" the code in the callee.
+	    \item \keyword{inline} is a compiler keyword that tells the compiler it's okay to omit the C function call procedure and "paste" the code in the callee.
         Instead, the compiler is hinted at substituting the function body directly into the calling function.
         This is not always recommended explicitly as the compiler is usually smart enough to know when to \keyword{inline} a function for you.
 


### PR DESCRIPTION
Typo: Had me looking up "moit" on Websters - apparently means "a foreign particle found in wool, as a burr, twig, or seed.". figured that wasn't what was meant.

@angrave 