### PR TITLE
Fix Triple Equal and replace Piazza with generic class forum

### DIFF
--- a/background/background.tex
+++ b/background/background.tex
@@ -199,7 +199,7 @@ nothing to commit, working directory clean
 \end{lstlisting}
 
 Don't panic, but your repository may be in an unworkable state.
-If you aren't nearing a deadline, come to office hours or ask your question on Piazza, and we'd be happy to help.
+If you aren't nearing a deadline, come to office hours or ask your question on Edstem, and we'd be happy to help.
 In an emergency scenario, delete your repository and re-clone (you'll have to add the \keyword{release} as above).
 \textbf{This will lose any local uncommitted changes. Make sure to copy any files you were working on outside the directory, remove and copy them back in}
 
@@ -986,15 +986,15 @@ Explain why this may be insufficient to generate a new build.
 \subsection{Optional: Just for fun}
 
 \begin{itemize}
-\item Convert a song lyrics into System Programming and C code covered in this wiki book and share on Piazza.
-\item Find, in your opinion, the best and worst C code on the web and post the link to Piazza.
-\item Write a short C program with a deliberate subtle C bug and post it on Piazza to see if others can spot your bug.
-\item Do you have any cool/disastrous system programming bugs you've heard about? Feel free to share with your peers and the course staff on Piazza.
+\item Convert a song lyrics into System Programming and C code covered in this wiki book and share on the class forum.
+\item Find, in your opinion, the best and worst C code on the web and post the link to the class forum.
+\item Write a short C program with a deliberate subtle C bug and post it on the class forum to see if others can spot your bug.
+\item Do you have any cool/disastrous system programming bugs you've heard about? Feel free to share with your peers and the course staff on the class forum.
 \end{itemize}
 
-\section{UIUC Specific Guidelines}
+\section{University of Illinois Specific Guidelines}
 
-\subsection{Piazza}
+\subsection{The class forum}
 
 TAs and student assistants get a ton of questions.
 Some are well-researched, and some are not.
@@ -1004,18 +1004,18 @@ Oh, and did I mention that this is an easy way to score points with your interns
 \begin{enumerate}
 \item Am I running on my Virtual Machine?
 \item \textbf{Did I check the man pages?}
-\item Have I searched for similar questions/followups on Piazza?
+\item Have I searched for similar questions/followups on the class forum?
 \item Have I read the MP/Lab specification completely?
 \item Have I watched all of the videos?
 \item Did I Google the error message and a few permutations thereof if necessary? How about StackOverflow.
 \item Did I try commenting out, printing, and/or stepping through parts of the code bit by bit to find out precisely where the error occurs?
 \item \textbf{Did I commit my code to git in case the TAs need more context?}
-\item Did I include the console/GDB/Valgrind output **AND** code surrounding the bug in my Piazza post?
+\item Did I include the console/GDB/Valgrind output **AND** code surrounding the bug in my the class forum post?
 \item Have I fixed other segmentation faults unrelated to the issue I'm having?
 \item Am I following good programming practice? (i.e. encapsulation, functions to limit repetition, etc)
 \end{enumerate}
 
-The biggest tip that we can give you when asking a question on piazza if you want a swift answer is to \textbf{ask your question like you were trying to answer it}. Like before you ask a question, try to answer it yourself. If you are thinking about posting
+The biggest tip that we can give you when asking a question on the class forum if you want a swift answer is to \textbf{ask your question like you were trying to answer it}. Like before you ask a question, try to answer it yourself. If you are thinking about posting
 
 \begin{quote}
 Hi, My code got a 50% on the autograder. I tried testing it a lot, but couldn't get it to fail. Can you give me some hints as to the test cases

--- a/introc/language_facilities.tex
+++ b/introc/language_facilities.tex
@@ -562,7 +562,7 @@ These operators are listed in order of precedence.
 	\item \keyword{+/-a} is the unary plus and minus operator. They either keep or negate the sign, respectively, of the integer or float type underneath.
 	\item \keyword{*a} is the dereference operator. If you have a pointer \keyword{*p}, you can use this to access the element located at this memory address. If you are reading, the return value will be the size of the underlying type. If you are writing, the value will be written with an offset.
 	\item \keyword{\&a} is the address-of operator. This takes an element and returns its address.
-	\item \keyword{++} is the increment operator. You can use it as a prefix or postfix, meaning that the variable that is being incremented can either be before or after the operator. \keyword{a = 0; ++a === 1} and \keyword{a = 1; a++ === 0}.
+	\item \keyword{++} is the increment operator. You can use it as a prefix or postfix, meaning that the variable that is being incremented can either be before or after the operator. \keyword{a = 0; ++a == 1} and \keyword{a = 1; a++ == 0}.
 	\item \keyword{-{}-} is the decrement operator. This has the same semantics as the increment operator except that it decreases the value of the variable by one.
 	\item \keyword{sizeof} is the sizeof operator, that is evaluated at the time of compilation. This is also mentioned in the keywords section.
 	\item \keyword{a <mop> b} where \keyword{<mop> in \{+, -, *, \%, /\}} are the arithmetic binary operators. If the operands are both number types, then the operations are plus, minus, times, modulo, and division respectively. If the left operand is a pointer and the right operand is an integer type, then only plus or minus may be used and the rules for pointer arithmetic are invoked.
@@ -607,7 +607,7 @@ sig >> 2; // 0000000000000000
     If a bit is set in the input, it will not be set in the output and vice versa.
 	\item \keyword{?:} is the ternary / conditional operator.
     You put a boolean condition before the \? and if it evaluates to non-zero the element before the colon is returned otherwise the element after is.
-    \keyword{1 ? a : b === a} and \keyword{0 ? a : b === b}.
+    \keyword{1 ? a : b == a} and \keyword{0 ? a : b == b}.
 	\item \keyword{a, b} is the comma operator.
     \keyword{a} is evaluated and then \keyword{b} is evaluated and \keyword{b} is returned.
     In a sequence of multiple statements delimited by commas, all statements are evaluated from left to right, and the right-most expression is returned.


### PR DESCRIPTION
Fixed typo === should be ==
Also replaced "Piazza" with "the class forum"