### PR TITLE
fix: remove duplicate "a program" in malloc section

### DIFF
--- a/malloc/malloc.tex
+++ b/malloc/malloc.tex
@@ -24,7 +24,7 @@ If \keyword{malloc} can either return a pointer to at least that much free space
 That means that malloc can return NULL even if there is some space.
 Robust programs should check the return value.
 If your code assumes \keyword{malloc} succeeds, and it does not, then your program will likely crash (segfault) when it tries to write to address 0.
-Also, malloc leaves garbage in memory because of performance -- check your code to make sure that a program all program values are initialized.
+Also, malloc leaves garbage in memory because of performance -- check your code to make sure that all program values are initialized.
 
 \item \keyword{realloc(void *space, size\_t bytes)} allows a program to resize an existing memory allocation that was previously allocated on the heap (via malloc, calloc, or realloc) \cite[P. 349]{jones2010wg14}.
 The most common use of realloc is to resize memory used to hold an array of values.


### PR DESCRIPTION
Fixes issue #214

Minor typo fix: removed duplicate "a program" in the malloc section (Section 5.2).

Before: "check your code to make sure that a program all program values are initialized."
After: "check your code to make sure that all program values are initialized."