### PR TITLE
Use a generic Edstem link in the background chapter

### DIFF
--- a/background/background.tex
+++ b/background/background.tex
@@ -845,7 +845,7 @@ The virtual machine-in-your-browser and the videos you need for HW0 are here:
 \url{http://cs-education.github.io/sys/}
 
 Questions? Comments? Use the current semester's CS341 Edstem:
-\url{https://edstem.org/us/courses/61021/discussion/}
+\url{https://edstem.org/}
 
 The in-browser virtual machine runs entirely in JavaScript and is fastest in Chrome.
 Note the VM and any code you write is reset when you reload the page, \textbf{so copy your code to a separate document.}


### PR DESCRIPTION
The Edstem URL in `background/background.tex` pointed at a specific past semester's course (`us/courses/61021/discussion/`), which no longer applies.

The preceding sentence already reads "Questions? Comments? Use the current semester's CS341 Edstem:", so linking `https://edstem.org/` lets that instruction stand on its own and avoids the link going stale each semester.

This was the only hardcoded Edstem course link in the repository.