### PR TITLE
Fix dead external links in the coursebook

### DIFF
--- a/appendix/appendix.tex
+++ b/appendix/appendix.tex
@@ -671,7 +671,7 @@ Thus, in practice, surrounding critical sections with a mutex lock and unlock ca
 For further reading, we suggest the following web post that discusses implementing Peterson's algorithm on an x86 process and the Linux documentation on memory barriers.
 \begin{enumerate}
 \item \href{http://bartoszmilewski.com/2008/11/05/who-ordered-memory-fences-on-an-x86/}{Memory Fences}
-\item \href{http://lxr.free-electrons.com/source/Documentation/memory-barriers.txt}{Memory Barriers}
+\item \href{https://www.kernel.org/doc/Documentation/memory-barriers.txt}{Memory Barriers}
 \end{enumerate}
 
 

--- a/background/background.tex
+++ b/background/background.tex
@@ -243,7 +243,7 @@ For this, we require sshfs which has ports on many different machines.
 
 \begin{enumerate}
 \item Windows \url{https://github.com/billziss-gh/sshfs-win}
-\item Mac \url{https://github.com/osxfuse/osxfuse/wiki/SSHFS}
+\item Mac \url{https://web.archive.org/web/20240913220726/https://github.com/osxfuse/osxfuse/wiki/SSHFS}
 \item Linux \url{https://help.ubuntu.com/community/SSHFS}
 \end{enumerate}
 

--- a/filesystems/filesystems.tex
+++ b/filesystems/filesystems.tex
@@ -1144,7 +1144,7 @@ Services must survive single disk, rack of servers, or whole data center failure
 
 \subsection{Solutions}
 Simple redundancy (2 or 3 copies of each file) e.g., Google GFS (2001).
-More efficient redundancy (analogous to RAID 3++) e.g., \href{http://goo.gl/LwFIy}{Google Colossus filesystem} (\textasciitilde{}2010): customizable replication including Reed-Solomon codes with 1.5x redundancy
+More efficient redundancy (analogous to RAID 3++) e.g., \href{https://web.archive.org/web/20160910131226/http://static.googleusercontent.com/media/research.google.com/en/us/university/relations/facultysummit2010/storage_architecture_and_challenges.pdf}{Google Colossus filesystem} (\textasciitilde{}2010): customizable replication including Reed-Solomon codes with 1.5x redundancy
 
 \section{Simple Filesystem Model}
 

--- a/malloc/malloc.tex
+++ b/malloc/malloc.tex
@@ -438,7 +438,7 @@ int s = (requested_bytes + tag_overhead_bytes + 15) / 16
 \end{lstlisting}
 
 The additional constant ensures incomplete units are rounded up. Note, real code is more likely to symbol sizes e.g. \keyword{sizeof(x)\ -\ 1}, rather than coding numerical constant 15.
-\href{http://www.ibm.com/developerworks/library/pa-dalign/}{Here's a great article on memory alignment, if you are further interested}
+\href{https://web.archive.org/web/20190313121701/https://www.ibm.com/developerworks/library/pa-dalign/}{Here's a great article on memory alignment, if you are further interested}
 
 Another added effect could be internal fragmentation happens when the given block is larger than their allocation size.
 Let's say that we have a free block of size 16B (not including metadata).

--- a/networking/networking.tex
+++ b/networking/networking.tex
@@ -436,7 +436,7 @@ For example, we haven't talked about \keyword{setsockopt} which can manipulate o
 You can also mess around with lower protocols as the kernel provides primitives that contribute to this.
 Note that you need to be root to create a raw socket.
 Also, you need to have a lot of ``set up'' or starter code, be prepared to have your datagrams be dropped due to bad form as well.
-For more information see this \href{http://www.beej.us/guide/bgnet/output/html/multipage/getaddrinfoman.html}{guide}.
+For more information see this \href{https://beej.us/guide/bgnet/html/split/man-pages.html#getaddrinfoman}{guide}.
 
 \subsection{Sending some data}
 

--- a/post_mortems/post_mortems.tex
+++ b/post_mortems/post_mortems.tex
@@ -163,7 +163,7 @@ Lessons Learned: Get an antivirus and/or apparmor and make sure that an applicat
 
 Required Sections: Intro to C
 
-\href{https://www.geek.com/games/why-gandhi-is-always-a-warmongering-jerk-in-civilization-1608515/}{Ghandi's Aggressiveness}
+\href{https://web.archive.org/web/20191216004115/https://www.geek.com/games/why-gandhi-is-always-a-warmongering-jerk-in-civilization-1608515/}{Ghandi's Aggressiveness}
 
 This is probably well known to gamers why someone as (in real life) non-violent as Ghandi was aggressive in the video game civilization.
 In the original, the game kept aggressiveness as an unsigned integer.


### PR DESCRIPTION
Checked all **133 distinct external URLs** across 20 `.tex` files and the repo's `.md` files, retrying every failure before concluding anything was dead. 6 links are genuinely gone and are fixed here.

## Changed

| file | old | new | why |
|---|---|---|---|
| `appendix/appendix.tex` | `lxr.free-electrons.com/.../memory-barriers.txt` | `kernel.org/doc/Documentation/memory-barriers.txt` | free-electrons became Bootlin; host resolves but refuses TCP |
| `networking/networking.tex` | `beej.us/guide/bgnet/output/html/multipage/getaddrinfoman.html` | `beej.us/guide/bgnet/html/split/man-pages.html#getaddrinfoman` | Beej retired that layout; 404 |
| `malloc/malloc.tex` | `ibm.com/developerworks/library/pa-dalign/` | Wayback snapshot | IBM retired developerWorks |
| `post_mortems/post_mortems.tex` | `geek.com/games/...civilization...` | Wayback snapshot | geek.com shut down |
| `filesystems/filesystems.tex` | `goo.gl/LwFIy` | Wayback snapshot of the Google Faculty Summit PDF | shortlink resolves, target PDF is 404 |
| `background/background.tex` | `github.com/osxfuse/osxfuse/wiki/SSHFS` | Wayback snapshot | page deleted; GitHub silently redirects to the macfuse wiki home |

Each Wayback snapshot was fetched (not just HEAD-ed) to confirm real archived content rather than an error page.

## Why this matters beyond tidiness

`_scripts/pandoc_header_filter.py` requests every link during the WIKI build. Until #220 an unreachable host aborted the build outright — `cyber.dhs.gov` did exactly that, and `lxr.free-electrons.com` (fixed here) was the next one queued up. #220 made that non-fatal, so these are no longer build-breaking, but they are still dead links in a published textbook.

## Deliberately NOT changed

- **14 × HTTP 403** — `linux.die.net` (×7), stackoverflow, pixabay, medium, appleinsider. Live sites blocking automated clients, fine in a browser.
- `gcc.gnu.org/wiki/Atomic/GCCMM/AtomicSync` — persistent 429 from their rate limiter, not a dead page.
- `dis.4chan.org/read/prog/1295544154` (the sleepsort origin) — Cloudflare 525, and no Wayback snapshot exists at any timestamp. No confident replacement.
- `www.gnu.org/software/emacs/tour/` — intermittent. It returned 200 and 403 at different points during testing and timed out at others. Not rewriting a canonical gnu.org URL on flaky evidence.
- Working redirects (org renames, http→https, article renumbering) left alone to keep the diff focused.

## Also worth knowing

`background/background.tex` contains `github.com/illinois-cs-coursework/fa23_cs341_<netid>` in a shell snippet — a per-student template, so it 404s by design, but the `fa23` prefix is stale. Left for a human call.