### PR TITLE
Move CI to Python 3.11 so it can run on ubuntu-26.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,14 +19,13 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    # Python 3.7 has no build for ubuntu-24.04 (which ubuntu-latest now
-    # points at), so setup-python could not find it. 3.9 is the newest
-    # release that still works with the pinned panflute 1.10.6, which
-    # imports MutableSequence from collections (removed in 3.10).
+    # Python 3.7 has no build for ubuntu-24.04 or 26.04, so setup-python
+    # could not find it. 3.11 has builds for 22.04, 24.04 and 26.04, and
+    # works with panflute 1.12.5, which still targets pandoc 2.7's AST.
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Install
       run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,14 +19,13 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    # Python 3.7 has no build for ubuntu-24.04 (which ubuntu-latest now
-    # points at), so setup-python could not find it. 3.9 is the newest
-    # release that still works with the pinned panflute 1.10.6, which
-    # imports MutableSequence from collections (removed in 3.10).
+    # Python 3.7 has no build for ubuntu-24.04 or 26.04, so setup-python
+    # could not find it. 3.11 has builds for 22.04, 24.04 and 26.04, and
+    # works with panflute 1.12.5, which still targets pandoc 2.7's AST.
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Install
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-panflute==1.10.6
+panflute==1.12.5
 PyYAML>=4.2b1
 Jinja2>=2.10.1
 requests==2.20.0


### PR DESCRIPTION
Follow-up to #220, which pinned Python 3.9 to get CI green. 3.9 has builds only for ubuntu-22.04 and 24.04, so it blocks a future move to 26.04 runners.

| version | linux builds |
|---|---|
| 3.7 | 20.04, 22.04 |
| 3.9 | 22.04, 24.04 |
| **3.11** | 22.04, 24.04, **26.04** |

## The premise behind the 3.9 pin was wrong

#220 settled on 3.9 because `panflute==1.10.6` does `from collections import MutableSequence`, removed in Python 3.10 — and panflute is pinned because it is coupled to pandoc 2.7's AST.

Those two facts are separable. **panflute 1.12.5** (Feb 2020) fixed the `collections` import *and* still targets pandoc-types 1.17.5.4, i.e. pandoc 2.7. The import fix landed in the 1.11 line, well before the pandoc 2.11 API break.

So the whole change is three lines. **`_scripts/install.sh`, the `Makefile` and all filters are untouched** — pandoc 2.7 stays, and its `.deb` depends only on `libc6`, `libgmp10`, `zlib1g`, so it keeps installing on 24.04/26.04.

## Verification

Both stacks were built and diffed — old (py3.9 + panflute 1.10.6 + pandoc 2.7) vs new (py3.11 + panflute 1.12.5 + pandoc 2.7), running the real `gen_wiki.py` over all 18 chapters and `make epub`:

- all 20 wiki files (`Home.md`, `_Sidebar.md`, 18 chapters) — **byte-identical**
- EPUB — identical unzipped, apart from the random `urn:uuid` and `dcterms:modified` stamp, which differ on every build regardless
- also clean and byte-identical on 3.12 and 3.14, so there is headroom
- filter APIs used by the repo (`run_filter`, `Str/Header/Image/Math/Link/RawInline/MetaMap`, `elem.content.list`, `elem.url`, `elem.title`) are unchanged between 1.10.6 and 1.12.5
- `requests==2.20.0` was the other suspect for 3.11; it installs and does real HTTPS on 3.11 (urllib3 1.24.3 is pure Python)

Not verifiable locally: `make pdf` (no TeX install here). That job touches Python only through `gen_order.py` — pure `yaml` + `print`, no panflute, no pandoc — which was run successfully on 3.11. CI on this PR exercises it for real.

## Explicitly not doing: the pandoc upgrade

Moving past pandoc 2.7 was also built and diffed, and it is a genuine project with published-artifact churn, so it is deliberately out of scope: `pandoc-citeproc` is gone (must become `--citeproc`), panflute 2.x hard-rejects pandoc 2.7's API version, every ```c fence becomes ```objectivec (landed in pandoc 2.8/2.9, unavoidable past 2.7), wiki pages gain visible YAML front matter, and in-text citations lose author text unless `pandoc_wiki_filter.py` switches to `stringify(elem)`.

pandoc **3.x** is a hard no as the repo stands: pandoc 3.0's `Figure` element moves `\caption{}` off the `Image` node, so every captioned figure reads as empty alt text and both `pandoc_header_filter.py` and `pandoc_epub_filter.py` abort with `NoAltTagException`. Adopting it means rewriting the accessibility checks in both filters.

## Also noticed, not fixed here

- `requests==2.20.0` is a 2018 release with known urllib3 CVEs, and there is already a `dependabot/pip/requests-2.32.2` branch. Worth unpinning separately.
- `gen_wiki.py` uses GNU-only `sed -i EXPR FILE`, which fails on BSD sed. Harmless for CI, but it blocks local builds on macOS.