### PR TITLE
Deploy with the built-in GITHUB_TOKEN instead of deploy keys

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    # Needed so the built-in GITHUB_TOKEN can push the deploy branches
+    # and the wiki.
+    permissions:
+      contents: write
+
     strategy:
       matrix:
         build_focus: [WIKI, EPUB, PDF]
@@ -36,6 +41,8 @@ jobs:
         bash _scripts/script.sh
 
     - name: Deploy site
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # https://github.community/t/github-actions-bot-email-address/17204/6
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -44,13 +51,20 @@ jobs:
         export COMMITTER_EMAIL="github-actions@github.com"
         export AUTHOR_NAME="Github Actions"
 
+        # The encrypted deploy keys below no longer authenticate: the repo
+        # has no deploy keys registered at all, so every push failed with
+        # "git@github.com: Permission denied (publickey)". They were most
+        # likely dropped when the org was renamed illinois-cs241 ->
+        # cs341-illinois. We now push with the built-in GITHUB_TOKEN
+        # instead, which needs no secret to rotate and survives renames.
+        #
         # Needed to add the --no-tty --batch --yes flags to get gpg to work in Github Actions
         # Based on this: https://discuss.circleci.com/t/error-sending-to-agent-inappropriate-ioctl-for-device/17465/3
-        gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/deploy_site --decrypt site-deploy.enc
-        gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/deploy_wiki --decrypt wiki-deploy.enc
-
-        eval "$(ssh-agent -s)"
-        chmod 600 /tmp/deploy_site
-        chmod 600 /tmp/deploy_wiki
+        # gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/deploy_site --decrypt site-deploy.enc
+        # gpg --no-tty --batch --yes --passphrase ${{ secrets.GPG_PASSPHRASE }} --output /tmp/deploy_wiki --decrypt wiki-deploy.enc
+        #
+        # eval "$(ssh-agent -s)"
+        # chmod 600 /tmp/deploy_site
+        # chmod 600 /tmp/deploy_wiki
 
         bash _scripts/deploy.sh

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -27,8 +27,8 @@ else
     # Grab an orphaned branch, so git doesn't calculate diffs
     git checkout --orphan $BRANCH;
 
-    # Set up ssh 
-    git config --global core.sshCommand "ssh -i /tmp/deploy_wiki -F /dev/null";
+    # Set up ssh
+    # git config --global core.sshCommand "ssh -i /tmp/deploy_wiki -F /dev/null";
 
 
     # Remove all other files, we won't need them
@@ -42,9 +42,10 @@ else
     git add -A;
     git commit -m "Adding build on $(date)" --author "$COMMITTER_EMAIL <$AUTHOR_NAME>" || true
 
-    # Swap the https origin for the ssh origin so we can push
+    # Push over https with the built-in GITHUB_TOKEN. Actions masks the
+    # token in the log, and it is scoped to this repo only.
     OLD_ORIGIN=`git remote get-url origin`;
-    git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git;
+    git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git";
     git push origin --force $BRANCH;
 
     # Swap it back

--- a/_scripts/push_to_wiki.sh
+++ b/_scripts/push_to_wiki.sh
@@ -8,9 +8,11 @@ DOCS_SHA=$(git rev-parse --short HEAD)
 # Create a temp directory, so we don't get raced by the filesystem
 WIKI_DIR=`mktemp -d`
 
-CLONE_URL="git@github.com:${GITHUB_REPOSITORY}.wiki.git"
-echo "Cloning $CLONE_URL into $WIKI_DIR"
-git config --global core.sshCommand "ssh -i /tmp/deploy_wiki -F /dev/null"
+# Push over https with the built-in GITHUB_TOKEN instead of the retired
+# deploy key. Echo the ssh form so the token never reaches the log.
+CLONE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git"
+echo "Cloning ${GITHUB_REPOSITORY}.wiki into $WIKI_DIR"
+# git config --global core.sshCommand "ssh -i /tmp/deploy_wiki -F /dev/null"
 git clone $CLONE_URL $WIKI_DIR
 
 # If we get race condition on read only files, we need to fix our build system
@@ -29,4 +31,14 @@ cd ${GITHUB_WORKSPACE}
 
 
 # Part 2, Update the site
-bash _scripts/site_deploy.sh
+#
+# Disabled. site_deploy.sh pushes an empty commit to a DIFFERENT repo to
+# nudge the website into rebuilding, and the built-in GITHUB_TOKEN is
+# scoped to this repo only, so it cannot do that. Re-enabling it needs a
+# PAT (or a deploy key) in a secret.
+#
+# It also still names illinois-cs241/illinois-cs241.github.io, which is
+# two renames stale - the site now lives at
+# cs341-illinois/cs341-illinois.github.io - so that URL needs updating
+# before this is switched back on.
+# bash _scripts/site_deploy.sh


### PR DESCRIPTION
Every deploy run fails at the final push:

```
git@github.com: Permission denied (publickey)
fatal: Could not read from remote repository.
```

## Cause

`gh api repos/cs341-illinois/coursebook/keys` returns an **empty list** — the repo has no deploy keys registered, so the keys inside `site-deploy.enc` and `wiki-deploy.enc` cannot authenticate against anything. Most likely they were dropped in the `illinois-cs241` → `cs341-illinois` org rename.

Note the GPG side is healthy: the log shows both `.enc` files decrypting fine, so `GPG_PASSPHRASE` is not the problem. The build itself also succeeds — the EPUB is produced and committed to `epub_deploy` — it only dies on the push.

## Change

Comment out the gpg + ssh-agent machinery and push over https with the built-in `GITHUB_TOKEN`, with `permissions: contents: write` on the job. No secret to rotate, and it survives future org renames.

| target | script | now uses |
|---|---|---|
| `epub_deploy` / `pdf_deploy` branches | `deploy.sh` | GITHUB_TOKEN |
| coursebook wiki | `push_to_wiki.sh` | GITHUB_TOKEN |
| the website repo | `site_deploy.sh` | **disabled — see below** |

The encrypted keys and the gpg lines are left in place, commented, so nothing is lost if you'd rather go back to deploy keys.

## site_deploy.sh stays off, deliberately

It pushes an **empty commit to a different repository** to nudge the website into rebuilding. `GITHUB_TOKEN` is scoped to this repo only, so it cannot do that — re-enabling needs a PAT (or a deploy key) in a secret.

It is also aimed at `illinois-cs241/illinois-cs241.github.io`, which is two renames stale; the site now lives at `cs341-illinois/cs341-illinois.github.io`. That URL needs fixing before it is switched back on regardless of which credential is used.

If the website no longer depends on that nudge, this can simply stay deleted.

## Verification status

`bash -n` clean on both scripts, and the workflow YAML parses with the expected `permissions` and `env` blocks. **The deploy path cannot be exercised by a PR** — `Coursebook Deploy` only runs on push to master — so the real test is the run that fires when this merges. Two things I could not verify in advance: whether `GITHUB_TOKEN` is accepted for the **wiki** repo specifically (it should be with `contents: write`, but wiki permissions are occasionally quirky), and whether branch protection would object to the force-push onto `epub_deploy`/`pdf_deploy`.