### PR TITLE
Re-enable the website trigger using a deploy key

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,6 +43,7 @@ jobs:
     - name: Deploy site
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SITE_DEPLOY_KEY: ${{ secrets.SITE_DEPLOY_KEY }}
       run: |
         # https://github.community/t/github-actions-bot-email-address/17204/6
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -66,5 +67,20 @@ jobs:
         # eval "$(ssh-agent -s)"
         # chmod 600 /tmp/deploy_site
         # chmod 600 /tmp/deploy_wiki
+
+        # Install the website deploy key so site_deploy.sh can nudge the
+        # site into rebuilding. GITHUB_TOKEN cannot do this: it is scoped
+        # to this repo, and pushes made with it deliberately do not
+        # trigger workflows. A deploy key has no expiry and is exempt
+        # from the org's SAML SSO. If the secret is absent (a fork, say)
+        # the site deploy is skipped rather than failing the run.
+        if [ -n "$SITE_DEPLOY_KEY" ]; then
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          printf '%s\n' "$SITE_DEPLOY_KEY" > /tmp/deploy_site
+          chmod 600 /tmp/deploy_site
+        else
+          echo "SITE_DEPLOY_KEY not set - the site deploy will be skipped"
+        fi
 
         bash _scripts/deploy.sh

--- a/_scripts/push_to_wiki.sh
+++ b/_scripts/push_to_wiki.sh
@@ -32,13 +32,12 @@ cd ${GITHUB_WORKSPACE}
 
 # Part 2, Update the site
 #
-# Disabled. site_deploy.sh pushes an empty commit to a DIFFERENT repo to
-# nudge the website into rebuilding, and the built-in GITHUB_TOKEN is
-# scoped to this repo only, so it cannot do that. Re-enabling it needs a
-# PAT (or a deploy key) in a secret.
-#
-# It also still names illinois-cs241/illinois-cs241.github.io, which is
-# two renames stale - the site now lives at
-# cs341-illinois/cs341-illinois.github.io - so that URL needs updating
-# before this is switched back on.
-# bash _scripts/site_deploy.sh
+# site_deploy.sh pushes an empty commit to the website repo to trigger a
+# rebuild there. That needs the SITE_DEPLOY_KEY deploy key, which the
+# workflow writes to /tmp/deploy_site. Skip rather than fail when it is
+# absent, so forks and any run without the secret still succeed.
+if [ -f /tmp/deploy_site ]; then
+    bash _scripts/site_deploy.sh
+else
+    echo "Skipping site deploy: /tmp/deploy_site is not present"
+fi

--- a/_scripts/site_deploy.sh
+++ b/_scripts/site_deploy.sh
@@ -2,12 +2,14 @@
 
 set -e;
 
-# Set up ssh
-git config --global core.sshCommand "ssh -i /tmp/deploy_site -F /dev/null"
+# Set up ssh. IdentitiesOnly stops ssh offering any other key it finds.
+git config --global core.sshCommand "ssh -i /tmp/deploy_site -o IdentitiesOnly=yes -F /dev/null"
 export DOCS_SHA=$(git rev-parse --short HEAD)
 
-# Clone with submodules
-git clone -b develop --depth 1 git@github.com:illinois-cs241/illinois-cs241.github.io.git ${CLONE_DIR}
+# Clone the site repo. The empty commit below is what triggers its
+# Website Deploy workflow, which pulls the coursebook wiki via the
+# _coursebook submodule and republishes.
+git clone -b develop --depth 1 git@github.com:cs341-illinois/cs341-illinois.github.io.git ${CLONE_DIR}
 cd ${CLONE_DIR}
 
 git commit --allow-empty -m "Updating docs to ${DOCS_SHA}"


### PR DESCRIPTION
Completes the deploy chain. #223 got the wiki publishing again via `GITHUB_TOKEN`, but left `site_deploy.sh` disabled, so a coursebook change only reaches the published site when something else happens to push to the website repo.

## Why a deploy key rather than GITHUB_TOKEN or a PAT

`GITHUB_TOKEN` cannot do this for two independent reasons: it is scoped to this repo only, and pushes made with it **deliberately do not trigger workflows** (GitHub's recursion guard) — so even if it could reach the site repo, the rebuild would not fire.

That leaves a PAT or a deploy key. Deploy key, because:

- **no expiry** — a lapsing PAT would recreate exactly the failure this repo just spent a year in, with a broken deploy nobody noticed
- **not tied to a person's account**
- **exempt from the org's SAML SSO** — verified: `git ls-remote` with this key reaches the site repo, while an SSO-unauthorised SSH key is refused

## Setup already done

- public half registered on `cs341-illinois.github.io` as deploy key **"coursebook deploy trigger"**, id 161113920, write access
- private half stored here as the `SITE_DEPLOY_KEY` secret
- read access verified against `refs/heads/develop` before wiring anything up

## Changes

- `deploy.yaml`: pass `SITE_DEPLOY_KEY`, write it to `/tmp/deploy_site`, seed `known_hosts` with `ssh-keyscan` rather than assuming the runner has github.com
- `site_deploy.sh`: point at `cs341-illinois/cs341-illinois.github.io` — it still named `illinois-cs241`, two renames stale — and add `IdentitiesOnly=yes`
- `push_to_wiki.sh`: re-enable the call, guarded on the key being present so forks and secret-less runs skip it instead of failing

## Expected propagation

~4–5 min end to end: coursebook WIKI build and wiki push ~2 min, then website build and Pages deploy ~2 min. The trigger lives in the WIKI job, so it does not wait on the 9-minute PDF job.

## What is still unverified

Write access is declared on the key but not exercised — I did not test-push junk to `develop`. The empty commit on the next deploy is the real test, and it only runs on push to master, so merging is the experiment.

## Noticed, not fixed here

`_scripts/gen_wiki.py` embeds several `illinois-cs241/coursebook` URLs (image sources, and the One Big PDF / EPUB links) that end up in the generated wiki. They still resolve via GitHub's org-rename redirect, so nothing is broken, but they are stale and would break if that redirect is ever dropped.