### PR TITLE
Speed up CI: install only the texlive packages the book needs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,11 +5,24 @@ on:
     branches:
       - master
 
+# A PR build has no side effects, so superseding one is always safe:
+# when someone pushes a fixup commit, kill the run for the old commit
+# rather than paying for a 9 minute PDF build nobody will look at.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
+      # The three outputs are independent, and PDF is by far the slowest.
+      # With the default fail-fast, a WIKI failure 90 seconds in cancels
+      # the 9 minute PDF job, so the run tells you nothing about whether
+      # the PDF is healthy and the next push has to rediscover it.
+      fail-fast: false
       matrix:
         build_focus: [WIKI, EPUB, PDF]
     env:
@@ -26,6 +39,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: pip
+        cache-dependency-path: requirements.txt
 
     - name: Install
       run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,9 +5,22 @@ on:
     branches:
       - master
 
+# Deploy pushes the wiki, force-pushes epub_deploy and pdf_deploy, and
+# nudges the website repo. Cancelling that halfway through can leave the
+# three deploy targets on different commits, so cancel-in-progress stays
+# FALSE: a second push to master queues behind the first instead of
+# killing it. GitHub keeps at most one run pending per group, so a burst
+# of pushes still collapses to "the run in flight, then the newest one" --
+# the intermediate ones are dropped before they start, which costs
+# nothing and is safe because only the newest commit needs deploying.
+concurrency:
+  group: deploy-master
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     # Needed so the built-in GITHUB_TOKEN can push the deploy branches
     # and the wiki.
@@ -15,6 +28,10 @@ jobs:
       contents: write
 
     strategy:
+      # WIKI, EPUB and PDF deploy to three independent targets. With
+      # the default fail-fast a WIKI failure cancels the PDF job, so
+      # pdf_deploy silently goes stale even though the PDF was fine.
+      fail-fast: false
       matrix:
         build_focus: [WIKI, EPUB, PDF]
     env:
@@ -31,6 +48,8 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: pip
+        cache-dependency-path: requirements.txt
 
     - name: Install
       run: |

--- a/_scripts/install.sh
+++ b/_scripts/install.sh
@@ -16,6 +16,36 @@ fi;
 
 if test $BUILD_FOCUS = "PDF"
 then
-    sudo apt update
-    sudo apt install texlive-full
+    # texlive-full drags in 455 packages / 4.0 GB -- every language pack,
+    # ConTeXt, Metapost, the lot -- and is the reason this job takes ~9
+    # minutes. The book needs 68 packages / 768 MB, listed below.
+    #
+    # Which package provides what (checked with apt-file on Ubuntu 24.04):
+    #   latex-base        book.cls fontenc geometry graphicx color hyperref
+    #                     natbib fancyhdr longtable grfext epstopdf-base
+    #   latex-recommended microtype listings xcolor setspace float chapterbib
+    #   latex-extra       mdframed mfirstuc comment framed glossaries titlesec
+    #                     tocloft wrapfig changepage csquotes epigraph fncychap
+    #   pictures          pgffor
+    #   fonts-recommended Charter type1 (bchr8a.pfb), Latin Modern
+    #   fonts-extra       mathdesign / mdbch. 614 MB of the 768 MB, so
+    #                     most of the remaining install time, but it is
+    #                     the only place mathdesign lives and it sets the
+    #                     book's body font. Dropping it changes every page.
+    #   luatex            lualatex, which the Makefile builds with
+    #   font-utils        epstopdf, for the 47 .eps drawings
+    #   latexmk           every build in the Makefile goes through latexmk
+    #   ghostscript       epstopdf's backend
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends \
+        texlive-latex-base \
+        texlive-latex-recommended \
+        texlive-latex-extra \
+        texlive-fonts-recommended \
+        texlive-fonts-extra \
+        texlive-pictures \
+        texlive-luatex \
+        texlive-font-utils \
+        latexmk \
+        ghostscript
 fi;


### PR DESCRIPTION
The PDF job takes ~9 minutes and *is* the workflow's wall clock (duration = max of the three matrix jobs). `install.sh` installs `texlive-full`: 455 packages, 4.0 GB, every language pack plus ConTeXt and Metapost. The book needs 68 packages, 768 MB.

## Measured, not estimated

Built the book both ways in `ubuntu:24.04` and compared:

| | packages | download | `apt install` | `make pdf` |
|---|---|---|---|---|
| `texlive-full` | 455 | 3995 MB | 270s | 188s |
| reduced set | 68 | **768 MB** | **92s** | **141s** |

**Output equivalence was verified, not assumed:** all 19 PDFs (main + 18 chapters) have identical page counts (`main.pdf` = 390 pages both ways), identical page sizes, and **byte-identical `pdftotext` output**, with no unresolved references in either build.

Each package is justified in a comment in `install.sh` — notably `texlive-fonts-extra`, which is 614 MB of the 768 and looks like an obvious cut, but is the only source of `mathdesign`/`mdbch`, the book's body font. Dropping it changes every page.

## Also in here

- **`fail-fast: false`** on both matrices. A WIKI failure 90 seconds in currently cancels the 9-minute PDF job — that happened repeatedly while fixing this pipeline, and the run then tells you nothing about whether the PDF is healthy. On deploy it is worse: `pdf_deploy` silently goes stale even though the PDF built fine.
- **`concurrency`, asymmetric on purpose.** PR builds have no side effects, so a superseded run is cancelled (`cancel-in-progress: true`). Deploy is **not** — it pushes the wiki, force-pushes `epub_deploy`/`pdf_deploy` and nudges the website repo; interrupting that can leave the three targets on different commits. A burst of pushes still collapses, because GitHub keeps at most one run pending per group.
- **`timeout-minutes: 30`** — the link checker does a live HEAD per external URL with a 15s timeout; 111 URLs worst case is ~28 minutes, and without a timeout a hang burns six hours.
- **pip cache** — marginal (five small pure-python wheels), but free.

## Rejected, with evidence

- **`make -j4`** cuts the build 146s → 80s and **produces a wrong book**: the appendix numbers as 13 instead of 17, and a cross-reference degrades to `??`. Do not.
- **Dropping `texlive-fonts-extra`** saves only 29s and needs `updmap` font-map surgery to install mathdesign from CTAN instead.
- **Path filters** — nearly every PR touches `.tex`, and a workflow-level `paths` filter makes required checks never report, which can wedge PRs.
- **A prebuilt `texlive/texlive` container** ships a newer TeX Live, risking exactly the output changes ruled out when pandoc 2.7 was kept.

## What this PR itself proves

All the timings above are arm64 Docker on macOS. The 5.2× download reduction is solid; translating it into GitHub seconds is not. **This PR's own CI run is the real amd64 measurement** — compare its PDF job against the ~8m53s–9m01s baseline from recent runs.

The one risk is an incomplete package set, which fails loudly (a missing `.sty` aborts the build) rather than silently producing a bad PDF. `--no-install-recommends` is used, so if something is missing it will show up here.

## Not included

The link-cache caching from the investigation is deliberately left out — it needs the `~/cache` path and its hit rate confirmed first, and it would not shorten the critical path anyway, only the deploy WIKI leg.