### PR TITLE
Make the PDF build fail on real LaTeX errors, and fix the errors it was hiding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,15 @@ $(ORDER_TEX): $(ORDER_TEX_DEP)
 $(CHAPTER_PDF): %.pdf: %.tex
 	echo '\\let\\cleardoublepage\\clearpage' > $@.tmp
 	echo "\includeonly{$(basename $^)}\input{$(MAIN_TEX)}" >> $@.tmp
-	-latexmk -interaction=nonstopmode -quiet -pdflatex=lualatex -f -pdf -jobname="$@" $@.tmp 2>&1 >/dev/null
+	@latexmk -interaction=nonstopmode -quiet -pdflatex=lualatex -pdf -jobname="$@" $@.tmp \
+		|| { echo "*** latexmk failed for $@"; grep -n -A3 '^! ' $@.log 2>/dev/null; rm -f $@.tmp; false; }
 	@mv $@.pdf $@
 	@ls $@ > /dev/null
 	-@rm $@.tmp
 
 $(MAIN_OUT): $(TEX) $(MAIN_TEX) $(BIBS) Makefile $(ORDER_TEX)
-	-@latexmk -quiet -pdflatex=lualatex -interaction=nonstopmode -f -pdf $(MAIN_TEX)
+	@latexmk -quiet -pdflatex=lualatex -interaction=nonstopmode -pdf $(MAIN_TEX) \
+		|| { echo "*** latexmk failed"; grep -n -A3 '^! ' $(basename $(MAIN_TEX)).log 2>/dev/null; false; }
 	@ls $(PDF_TEX) > /dev/null
 	@mv $(PDF_TEX) $(MAIN_OUT)
 	@echo "Finished"

--- a/appendix/appendix.tex
+++ b/appendix/appendix.tex
@@ -105,7 +105,7 @@ This overwrites the file from the beginning.
 If you only meant to append to the file, you can use \keyword{>>}.
 Unix also allows file descriptor swapping.
 This means that you can take the output going to one file descriptor and make it seem like it's coming out of another.
-The most common one is \keyword{2>&1} which means take the stderr and make it seem like it is coming out of standard out.
+The most common one is \keyword{2>\&1} which means take the stderr and make it seem like it is coming out of standard out.
 This is important because when you use \keyword{>} and \keyword{>>} they only write the standard output of the file.
 There are some examples below.
 
@@ -134,7 +134,7 @@ $ ((head output.txt) | wc) | head -n 1 # Same as above
 $ ./program | tee intermediate.txt | wc
 \end{lstlisting}
 
-The \keyword{&&} and \keyword{||} operator are operators that execute a command sequentially. \keyword{&&} only executes a command if the previous command succeeds, and \keyword{||} always executes the next command.
+The \keyword{\&\&} and \keyword{||} operator are operators that execute a command sequentially. \keyword{\&\&} only executes a command if the previous command succeeds, and \keyword{||} always executes the next command.
 
 \begin{lstlisting}[language=bash]
 $ false && echo "Hello!"
@@ -693,7 +693,6 @@ answer = 42
 pthread_cond_signal(cv);
 \end{lstlisting}
 
-\\
 \begin{center}
 \begin{table}[h]
 \caption{Signaling without Mutex}
@@ -706,7 +705,6 @@ pthread_cond_signal(cv);
 \end{tabular}
 \end{table}
 \end{center}
-\\
 The problem here is that a programmer expects the signal to wake up the waiting thread.
 Since instructions are allowed to be interleaved without a mutex, this causes an interleaving that is confusing to application designers.
 Note that technically the API of the condition variable is satisfied.
@@ -987,7 +985,7 @@ We'll talk about a language go that is similar to C in terms of simplicity and d
 To get the 5 minute introduction, feel free to read \href{https://learnxinyminutes.com/docs/go/}{the learn x in y guide} for go.
 Here is how we create a "thread" in go.
 
-\begin{lstlisting}[language=golang]
+\begin{lstlisting}[language=Go]
 func hello(out) {
     fmt.Println(out);
 }
@@ -1010,7 +1008,7 @@ There is no boilerplate code, or joining, or odd casting \keyword{void *}.
 We can still use mutexes in go to perform our end result.
 Consider the counting example as before.
 
-\begin{lstlisting}[language=golang]
+\begin{lstlisting}[language=Go]
 var counter = 0;
 var mut sync.Mutex;
 var wg sync.WaitGroup;
@@ -1045,7 +1043,7 @@ The counter is responsible for adding numbers to an internal variable.
 We'll send messages between the threads when we want to add and see the value.
 
 
-\begin{lstlisting}[language=golang]
+\begin{lstlisting}[language=Go]
 const (
   addRequest = iota;
   outputRequest = iota;

--- a/background/background.tex
+++ b/background/background.tex
@@ -624,7 +624,7 @@ There are a whole load more resources on the web, here are a few specific ones t
 \begin{enumerate}
 \item \href{http://www.cs.cmu.edu/~gilpin/tutorial/}{Introduction to gdb}
 \item \href{https://ftp.gnu.org/old-gnu/Manuals/gdb/html_node/gdb_toc.html}{GDB Manual}
-\item \href{https://www.youtube.com/watch?v=PorfLSr3DDI}{CppCon 2015: Greg Law “Give me 15 minutes & I'll change your view of GDB”}
+\item \href{https://www.youtube.com/watch?v=PorfLSr3DDI}{CppCon 2015: Greg Law “Give me 15 minutes \& I'll change your view of GDB”}
 \end{enumerate}
 
 \subsection{Shell}

--- a/introc/c_memory_model.tex
+++ b/introc/c_memory_model.tex
@@ -117,7 +117,7 @@ In C, we have
 \href{https://en.wikipedia.org/wiki/String_(computer_science)\#Length-prefixed}{Length
 	Prefixed} for historical reasons.
 For everyday programmers, remember to NUL terminate your string!
-A string in C is defined as a bunch of bytes ended by `\0' or the NUL Byte.
+A string in C is defined as a bunch of bytes ended by `\textbackslash 0' or the NUL Byte.
 
 \subsection{Places for strings}
 

--- a/introc/common_bugs.tex
+++ b/introc/common_bugs.tex
@@ -112,7 +112,7 @@ gets(array); // Let's hope the input is shorter than my array!
 \subsection{Strings require strlen(s)+1 bytes}
 
 Every string must have a NUL byte after the last character.
-To store the string ``Hi'' it takes 3 bytes: [H] [i] [\backslash 0].
+To store the string ``Hi'' it takes 3 bytes: [H] [i] [\textbackslash 0].
 
 \begin{lstlisting}[language=C]
 char *strdup(const char *input) {  /* return a copy of 'input' */

--- a/introc/common_c_functions.tex
+++ b/introc/common_c_functions.tex
@@ -279,7 +279,7 @@ Any behavior missing from the documentation, such as the result of \keyword{strl
 
 	      \textbf{Output}
 
-	      \begin{lstlisting}[language=console]
+	      \begin{lstlisting}
 strtok
 is
 tricky

--- a/introc/crash_course_introduction_to_c.tex
+++ b/introc/crash_course_introduction_to_c.tex
@@ -22,10 +22,10 @@ int main(void) {
     For regular functions having a declaration like \keyword{void func()} means that the function can be called like \keyword{func(1, 2, 3)}, because there is no delimiter.
     \keyword{main} is a special function.
     There are many ways of declaring \keyword{main} but the standard ones are \keyword{int main(void)}, \keyword{int main()}, and \keyword{int main(int argc, char *argv[])}.
-	\item \keyword{printf("Hello World\n");} is a function call.
+	\item \keyword{printf("Hello World\textbackslash n");} is a function call.
     \keyword{printf} is defined as a part of \keyword{stdio.h}.
     The function has been compiled and lives somewhere else on our machine - the location of the C standard library.
-    Just remember to include the header and call the function with the appropriate parameters (a string literal \keyword{"Hello World\n"}).
+    Just remember to include the header and call the function with the appropriate parameters (a string literal \keyword{"Hello World\textbackslash n"}).
     If the newline isn't included, the buffer will not be flushed (i.e. the write will not complete immediately).
 	\item \keyword{return 0}.
     \keyword{main} has to return an integer.

--- a/introc/language_facilities.tex
+++ b/introc/language_facilities.tex
@@ -20,7 +20,6 @@ switch(1) {
     break;
 } /* Continues here */
 \end{lstlisting}
-	      \\
 	      In the context of a loop, using it breaks out of the inner-most loop.
         The loop can be either a \keyword{for}, \keyword{while}, or \keyword{do-while} construct
 	      \\
@@ -512,7 +511,6 @@ while(flag) {
     // Do things unrelated to flag
 }
 \end{lstlisting}
-	      \\
 	      The compiler may, since the internals of the while loop have nothing to do with the flag, optimize it to the following even though a function may alter the data.
 	      \\
 	      \begin{lstlisting}[language=C]
@@ -606,7 +604,7 @@ sig >> 2; // 0000000000000000
 	\item \keyword{~~} is the bitwise NOT operator.
     If a bit is set in the input, it will not be set in the output and vice versa.
 	\item \keyword{?:} is the ternary / conditional operator.
-    You put a boolean condition before the \? and if it evaluates to non-zero the element before the colon is returned otherwise the element after is.
+    You put a boolean condition before the ? and if it evaluates to non-zero the element before the colon is returned otherwise the element after is.
     \keyword{1 ? a : b == a} and \keyword{0 ? a : b == b}.
 	\item \keyword{a, b} is the comma operator.
     \keyword{a} is evaluated and then \keyword{b} is evaluated and \keyword{b} is returned.

--- a/introduction/introduction.tex
+++ b/introduction/introduction.tex
@@ -25,5 +25,5 @@ Thanks again and happy reading!
 
 \section{Authors}
 
-\lstinputlisting[language=console]{AUTHORS.md}
+\lstinputlisting{AUTHORS.md}
 

--- a/main.tex
+++ b/main.tex
@@ -56,13 +56,6 @@
 %% Go to the next page if a section only has 3 lines
 \widowpenalties 3 10000 10000 0
 
-% this is a terrible hack, but pandoc sucks
-% we have to call any
-\lstnewenvironment{minted}{m}
-  {\noindent\minipage{\linewidth}\medskip 
-   \lstset{basicstyle=\ttfamily\footnotesize,frame=single,language=#1}}
-  {\endminipage}
-
 \usepackage{tocloft}
 
 %% Add some space to the table of contents justification

--- a/networking/networking.tex
+++ b/networking/networking.tex
@@ -553,7 +553,7 @@ In general, there are six parts:
 \item The method. GET, POST, etc.
 \item The resource. ``/'' ``/index.html'' ``/image.png''
 \item The protocol ``HTTP/1.0''
-\item A new line (\keyword{\\r\\n}). Requests always have a carriage return.
+\item A new line (\keyword{\textbackslash r\textbackslash n}). Requests always have a carriage return.
 \item Any other knobs or switch parameters
 \item The actual body of the request delimited by two new lines. The body of the request is either if the size is specified or until the receiver closes their connection.
 \end{enumerate}

--- a/prelude.tex
+++ b/prelude.tex
@@ -13,7 +13,7 @@
 \setlength{\columnsep}{.5in}
 
 \usepackage{fancyhdr}
-\usepackage{xcolor}
+\usepackage[usenames,dvipsnames]{xcolor}
 \usepackage{mdframed}
 \usepackage{setspace}
 \usepackage{mfirstuc}
@@ -40,7 +40,6 @@ columns=flexible,
 breaklines=true
 }
 
-\usepackage[usenames,dvipsnames]{color}
 \definecolor{greencomments}{rgb}{0,0.5,0}
 \definecolor{redstrings}{rgb}{0.9,0,0}
 \definecolor{mygreen}{rgb}{0,0.6,0}
@@ -69,8 +68,6 @@ breaklines=true
 belowskip=20pt,
 xleftmargin=1.5cm,
 xrightmargin=1.5cm,
-xtopmargin=1cm,
-xbottommargin=1cm,
 framexrightmargin=.5em,
 framexleftmargin=.5em,
 frame=bt,
@@ -105,10 +102,7 @@ rulecolor=\color{shadecolor},}
 \newcommand{\keyword}[1]{\underline{\smash{\textbf{\texttt{#1}}}}}
 \newcommand{\todo}[1]{}
 \renewcommand{\todo}[1]{{\color{red} TODO: {#1}}}
-\lstnewenvironment{lstlisting}[1][]%
-  {\noindent\minipage{\linewidth}\medskip
-   \lstset{basicstyle=\ttfamily\footnotesize,frame=single,#1}}
-  {\endminipage}
+\providecommand{\tightlist}{\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
 % For pictures
 \newenvironment{proof}{\begin{shaded*}\paragraph{Proof:}}{\hfill$\square$\end{shaded*}}
@@ -125,7 +119,7 @@ rulecolor=\color{shadecolor},}
 
 % this is a terrible hack, but pandoc sucks
 % we have to call any
-\lstnewenvironment{minted}{m}
+\lstnewenvironment{minted}[1]
   {\noindent\minipage{\linewidth}\medskip 
    \lstset{basicstyle=\ttfamily\footnotesize,frame=single,language=#1}}
   {\endminipage}

--- a/signals/signals.bib
+++ b/signals/signals.bib
@@ -1,8 +1,8 @@
 @misc{pthread_sigmask, 
-	title={pthread_sigmask}, 
+	title={pthread\_sigmask}, 
 	url={http://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_sigmask.html}, 
-	journal={pthread_sigmask}, 
-	publisher={IEEE}} 
+	journal={pthread\_sigmask}, 
+	publisher={IEEE}}
 
 @misc{execute, 
 	title={Executing a File}, 

--- a/signals/signals.tex
+++ b/signals/signals.tex
@@ -63,7 +63,6 @@ As a flowchart
 
 Here are some common signals that you will see thrown around.
 
-\\
 \begin{center}
 \begin{table}[h]
 \caption{POSIX Signals}
@@ -78,7 +77,6 @@ SIGKILL & 9 & Terminate Process (Cannot be caught) & You want the process gone
 \end{tabular}
 \end{table}
 \end{center}
-\\
 
 One of our favorite anecdotes is to never use \keyword{kill -9} for a host of reasons.
 The following is an excerpt from \underline{Useless Use of Kill -9} \href{http://porkmail.org/era/unix/award.html}{Link to archive}.

--- a/synchronization/synchronization.tex
+++ b/synchronization/synchronization.tex
@@ -50,7 +50,6 @@ If the threads had accessed the sum at different times then the count would have
 A few of the possible different orderings are below.
 
 Permissible Pattern
-\\
 \begin{center}
 \begin{table}[h]
 \caption{Good Thread Access Pattern}
@@ -63,10 +62,8 @@ Permissible Pattern
 \end{tabular}
 \end{table}
 \end{center}
-\\
 Partial Overlap
 
-\\
 \begin{center}
 \begin{table}[h]
 \caption{Bad Thread Access Pattern}
@@ -78,10 +75,8 @@ Store (i=1 globally) & Load Addr, Add 1 (i=1 locally) \\
 \end{tabular}
 \end{table}
 \end{center}
-\\
 
 Full Overlap
-\\
 \begin{center}
 \begin{table}[h]
 \caption{Horrible Thread Access Pattern}
@@ -92,7 +87,6 @@ Store (i=1 globally) & Store (i=1 globally) \\
 \end{tabular}
 \end{table}
 \end{center}
-\\
 We would like the first pattern of the code being mutually exclusive.
 Which leads us to our first synchronization primitive, a Mutex.
 
@@ -124,7 +118,7 @@ For all mutexes, there are two ways of initializing a mutex:
 \item\keyword{PTHREAD\_MUTEX\_INITIALIZER}
 \item\keyword{pthread\_mutex\_init(pthread\_mutex\_t *mutex, pthread\_mutexattr\_t *attr)}
 \end{itemize}
-The macro \keyword{PTHREAD\_MUTEX\_INITIALIZER} is functionally equivalent to the more general purpose \keyword{pthread\_mutex\_init(&m,NULL)}.
+The macro \keyword{PTHREAD\_MUTEX\_INITIALIZER} is functionally equivalent to the more general purpose \keyword{pthread\_mutex\_init(\&m,NULL)}.
 In other words, \keyword{PTHREAD\_MUTEX\_INITIALIZER} will create a mutex with default properties.
 The \keyword{attr} in the init version includes options to trade performance for additional error-checking, advanced sharing, and more.
 While we recommend using the init function inside of a program for a mutex located on the heap, you can use either method.
@@ -137,7 +131,7 @@ pthread_mutex_destroy(lock);
 free(lock);
 \end{lstlisting}
 
-Once we are finished with the mutex we should also call \keyword{pthread\_mutex\_destroy(&m)} too.
+Once we are finished with the mutex we should also call \keyword{pthread\_mutex\_destroy(\&m)} too.
 Note, a program can only destroy an unlocked mutex, destroy on a locked mutex is undefined behavior.
 Things to keep in mind about initializing and destroying mutexes:
 
@@ -1070,7 +1064,6 @@ It is impossible for two threads to be inside the critical section at the same t
 However, this code suffers from deadlock!
 Suppose two threads wish to enter the critical section at the same time.
 
-\\
 \begin{center}
 \begin{table}[h]
 \caption{Candidate Solution \#2 Analysis}
@@ -1082,7 +1075,6 @@ Time & Thread 1 & Thread 2 \\ \hline
 \end{tabular}
 \end{table}
 \end{center}
-\\
 
 Both processes are now waiting for the other one to lower their flags.
 Neither one will enter the critical section as both are now stuck forever!
@@ -1133,7 +1125,6 @@ The turn flag now points to the second thread.
 While the first thread is still inside the Critical Section, the second thread arrives.
 The second thread can immediately continue into the Critical Section!
 
-\\
 \begin{center}
 \begin{table}[h]
 \caption{Candidate Solution \#4}
@@ -1146,7 +1137,6 @@ Time & Turn & Thread \# 1 & Thread \# 2 \\ \hline
 \end{tabular}
 \end{table}
 \end{center}
-\\
 
 \section{Working Solutions}
 
@@ -1480,7 +1470,7 @@ int main() {
 \end{lstlisting}
 
 We will use the mutex to ensure that only one thread modifies \keyword{remain} at a time.
-The last arriving thread needs to wake up \emph{all} sleeping threads - so we will use \keyword{pthread\_cond\_broadcast(&cv)} not \keyword{pthread\_cond\_signal}.
+The last arriving thread needs to wake up \emph{all} sleeping threads - so we will use \keyword{pthread\_cond\_broadcast(\&cv)} not \keyword{pthread\_cond\_signal}.
 
 \begin{lstlisting}[language=C]
 pthread_mutex_lock(&m);


### PR DESCRIPTION
The PDF build could not fail. `Makefile:45,51` suppressed latexmk failures four ways: `-interaction=nonstopmode`, `-f`, a leading `-` so make ignored the exit code, and `-quiet` with output sent to `/dev/null`.

With that removed, the baseline build turns out to have **222 error lines** in `main_wrapper.log`, every one of them silently swallowed for years.

## This is not cosmetic — it is corrupting the published book

These are from the PDF published **today**, after this morning's deploy:

| page | what students read now | what it should say |
|---|---|---|
| 64 | "a boolean condition before the **and** if it evaluates…" | before the **`?`** |
| 75 | "a bunch of bytes ended by **''** or the NUL Byte" | ended by **`\0`** |
| 349 | "The most common one is **`2>1`**" | **`2>&1`** |

The ternary-operator section omits the ternary operator. The string section omits the null terminator. Page 349 is the worst: `2>1` is not a rendering artefact, it is **wrong shell syntax** — it redirects stderr into a file named `1` instead of merging it into stdout. A student who copies it gets silently wrong behaviour.

Each was an unescaped `&` or an undefined control sequence (`\n`, `\0`, `\?`) that LaTeX reported and the build discarded.

## The Makefile change

| | before | after |
|---|---|---|
| recipe prefix | `-` (make ignores exit code) | removed |
| `-f` | force past errors | removed |
| output | `2>&1 >/dev/null` | shown |
| on failure | nothing | `grep '^! ' $@.log` to surface the actual error |

`-interaction=nonstopmode` is **kept** so a broken build cannot hang CI, and `-quiet` is kept so successful builds stay readable. Warnings still pass: overfull/underfull hboxes, font substitution, and undefined references (latexmk reruns to resolve those) all exit 0; only real errors exit non-zero. That distinction was verified by controlled test, not assumed.

## Verified both directions, in Docker

Using the same reduced texlive set CI uses on `ubuntu:24.04`:

- **Succeeds** on this branch: exit 0, zero errors in `main_wrapper.log` and in all 18 chapter logs, 19 PDFs produced.
- **Fails** when `\keyowrd` is deliberately reintroduced in a scratch copy: exit 2, `! Undefined control sequence l.23 \keyowrd`, `make: *** [Makefile:52: main.pdf] Error 1`, and no PDF produced.

A tightened build that never actually fails would be indistinguishable from success, so the second test is the important one.

## What else was fixed to get to zero errors

Preamble: an `xcolor`/`color` option clash; invalid `xtopmargin`/`xbottommargin` listings options; `\lstnewenvironment{minted}{m}` (wrong argument specifier) → `[1]`; `\tightlist` used 36 times across 11 files but never defined → `\providecommand`. `main.tex` had a duplicate `minted` definition. `signals/signals.bib` had an unescaped `_` that cascaded into 15 errors and broke the bibliography. Source files: the escaping fixes above, `language=golang` → `language=Go`, `language=console` (not a real listings language) removed, and 14 stray `\\` before `\begin{center}` that LaTeX was reporting as "no line here to end".

## Two things needing your judgement

1. **Page count moves 390 → 388.** `\lstnewenvironment{minted}{m}` never worked, so 8 `minted` blocks were rendering as broken plain text; with `[1]` they render as intended in framed minipages. That is an output change to the published book — an improvement, but it should be your call.

2. **A `\lstnewenvironment{lstlisting}` redefinition in `prelude.tex` was removed.** It was meant to wrap all 490 listings in framed minipages, but it redefined an environment that already existed, so it errored and never took effect. Removing it changes nothing today. If you *want* that framing, it needs implementing properly under a different name — which would change the appearance of all 490 listings.

## Not verified

The WIKI and EPUB paths could not be exercised locally: the available pandoc is 3.1.3, while CI pins 2.7 (and `pandoc-citeproc` is gone in 3.x). Those recipes are unchanged and pandoc parses the modified `main.tex` cleanly, but **this PR's own CI run is the real test** — and it matters here, because `prelude.tex` and `main.tex` feed the EPUB path too.